### PR TITLE
Check that we can set field value

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -68,7 +68,7 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 				fromField := source.FieldByName(name)
 				toField := dest.FieldByName(name)
 				toMethod := dest.Addr().MethodByName(name)
-				if fromField.IsValid() && toField.IsValid() {
+				if fromField.IsValid() && toField.IsValid() && toField.CanSet() {
 					toField.Set(fromField)
 				}
 
@@ -85,7 +85,7 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 				fromMethod := source.Addr().MethodByName(name)
 				toField := dest.FieldByName(name)
 
-				if fromMethod.IsValid() && toField.IsValid() {
+				if fromMethod.IsValid() && toField.IsValid() && toField.CanSet() {
 					values := fromMethod.Call([]reflect.Value{})
 					if len(values) >= 1 {
 						toField.Set(values[0])

--- a/copier_test.go
+++ b/copier_test.go
@@ -13,6 +13,7 @@ type User struct {
 	Role  string
 	Age   int32
 	Notes []string
+	flags []byte
 }
 
 func (user *User) DoubleAge() int32 {
@@ -26,6 +27,7 @@ type Employee struct {
 	DoubleAge int32
 	SuperRule string
 	Notes     []string
+	flags     []byte
 }
 
 func (employee *Employee) Role(role string) {
@@ -33,7 +35,7 @@ func (employee *Employee) Role(role string) {
 }
 
 func TestCopyStruct(t *testing.T) {
-	user := User{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}
+	user := User{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}, flags: []byte{'x'}}
 	employee := Employee{}
 
 	Copy(&employee, &user)


### PR DESCRIPTION
This PR fixes an error with unexported struct fields:
```
--- FAIL: TestCopyStruct (0.00s)
panic: reflect: reflect.Value.Set using value obtained using unexported field [recovered]
        panic: reflect: reflect.Value.Set using value obtained using unexported field

goroutine 5 [running]:
testing.func·006()
        /usr/lib/go/src/testing/testing.go:441 +0x181
reflect.flag.mustBeAssignable(0xf7)
        /usr/lib/go/src/reflect/value.go:219 +0x155
reflect.Value.Set(0x50eec0, 0xc208010130, 0xf7, 0x50eec0, 0xc208038220, 0xf7)
        /usr/lib/go/src/reflect/value.go:1292 +0x28
github.com/corpix/copier.Copy(0x547440, 0xc2080100e0, 0x547500, 0xc2080381e0, 0x0, 0x0)
        /home/vagrant/code/go/src/github.com/corpix/copier/copier.go:72 +0x833
github.com/corpix/copier.TestCopyStruct(0xc208062000)
        /home/vagrant/code/go/src/github.com/corpix/copier/copier_test.go:41 +0x19b
testing.tRunner(0xc208062000, 0x640da0)
        /usr/lib/go/src/testing/testing.go:447 +0xbf
created by testing.RunTests
        /usr/lib/go/src/testing/testing.go:555 +0xa8b

goroutine 1 [chan receive]:
testing.RunTests(0x5c20b8, 0x640da0, 0x3, 0x3, 0xabd6369d9bb20b01)
        /usr/lib/go/src/testing/testing.go:556 +0xad6
testing.(*M).Run(0xc2080360a0, 0x649b20)
        /usr/lib/go/src/testing/testing.go:485 +0x6c
main.main()
        github.com/corpix/copier/_test/_testmain.go:62 +0x1d5
FAIL    github.com/corpix/copier        0.001s
```