### PR TITLE
Prevent mismatched types (struct -> non-struct) in a copy from panicing.

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -64,15 +64,21 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 
 			if fromField := source.FieldByName(name); fromField.IsValid() {
 				// has field
-				if toField := dest.FieldByName(name); toField.IsValid() {
-					if toField.CanSet() {
-						if !set(toField, fromField) {
-							if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
-								return err
+				triedTo := false
+				if dest.Kind() == reflect.Struct {
+					if toField := dest.FieldByName(name); toField.IsValid() {
+						triedTo = true
+						if toField.CanSet() {
+							if !set(toField, fromField) {
+								if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
+									return err
+								}
 							}
 						}
 					}
-				} else {
+				}
+
+				if !triedTo {
 					// try to set to method
 					var toMethod reflect.Value
 					if dest.CanAddr() {

--- a/copier_test.go
+++ b/copier_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jinzhu/copier"
+	"time"
 )
 
 type User struct {
@@ -185,5 +186,31 @@ func TestEmbedded(t *testing.T) {
 
 	if base.BaseField1 != 1 {
 		t.Error("Embedded fields not copied")
+	}
+}
+
+func TestMismatchedStructToSimple(t *testing.T) {
+	// Types don't match.  Nothing should be copied to the mismatched field, but it should not panic.
+	type From struct {
+		Tmp  time.Time
+		Safe int64
+	}
+
+	type To struct {
+		Tmp  string
+		Safe int64
+	}
+
+	from := From{}
+	from.Tmp = time.Now()
+	from.Safe = 1
+	to := To{}
+	copier.Copy(&to, &from)
+
+	if to.Tmp != "" {
+		t.Error("Simple string field populated from complex data type incorrectly.")
+	}
+	if to.Safe != 1 {
+		t.Error("Simple integer field did not copy correctly.")
 	}
 }


### PR DESCRIPTION
If a field in the struct being copied is a struct has the same name in the struct being copied to, but the field in the struct being copied to is not a struct but a simple type, previously we would get a panic.

This change just has the code fall through the attempt at copying the struct into the simple field.  Patch includes new test demonstrating this behavior, all tests pass.