### PR TITLE
Feature/options

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -154,6 +154,13 @@ func indirectType(reflectType reflect.Type) reflect.Type {
 func set(to, from reflect.Value) bool {
 	if from.IsValid() {
 		if to.Kind() == reflect.Ptr {
+			// This won't stomp down on TO with a nil value. So if TO is already populated, not sure
+			// want expected behavior is (copy vs merge)
+			if (from.Kind() == reflect.Ptr || from.Kind() == reflect.Map || from.Kind() == reflect.Slice) && from.IsNil() {
+				return true // leave to as Nil
+			} else if from.Interface() == reflect.Zero(from.Type()).Interface() {
+				return true // if from is zero valued, leave to pointer as nil
+			}
 			if to.IsNil() {
 				to.Set(reflect.New(to.Type().Elem()))
 			}

--- a/copier.go
+++ b/copier.go
@@ -6,19 +6,25 @@ import (
 	"reflect"
 )
 
+const (
+	DisableScanner = iota
+)
+
+type CopyOption int
+
 // Copy copy things
-func Copy(toValue interface{}, fromValue interface{}) (err error) {
+func Copy(toValue interface{}, fromValue interface{}, flags ...CopyOption) (err error) {
 	var (
 		isSlice bool
 		amount  = 1
 		from    = indirect(reflect.ValueOf(fromValue))
 		to      = indirect(reflect.ValueOf(toValue))
+		opts    = createOptions(flags)
 	)
 
 	if !to.CanAddr() {
 		return errors.New("copy to value is unaddressable")
 	}
-
 	// Return is from value is invalid
 	if !from.IsValid() {
 		return
@@ -66,7 +72,7 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 				// has field
 				if toField := dest.FieldByName(name); toField.IsValid() {
 					if toField.CanSet() {
-						if !set(toField, fromField) {
+						if !set(toField, fromField, opts) {
 							if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
 								return err
 							}
@@ -151,7 +157,11 @@ func indirectType(reflectType reflect.Type) reflect.Type {
 	return reflectType
 }
 
-func set(to, from reflect.Value) bool {
+func set(to, from reflect.Value, options ...map[CopyOption]bool) bool {
+	opts := make(map[CopyOption]bool)
+	if len(options) != 0 {
+		opts = options[0]
+	}
 	if from.IsValid() {
 		if to.Kind() == reflect.Ptr {
 			// This won't stomp down on TO with a nil value. So if TO is already populated, not sure
@@ -166,10 +176,9 @@ func set(to, from reflect.Value) bool {
 			}
 			to = to.Elem()
 		}
-
 		if from.Type().ConvertibleTo(to.Type()) {
 			to.Set(from.Convert(to.Type()))
-		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok {
+		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok && !opts[DisableScanner] {
 			scanner.Scan(from.Interface())
 		} else if from.Kind() == reflect.Ptr {
 			return set(to, from.Elem())
@@ -178,4 +187,12 @@ func set(to, from reflect.Value) bool {
 		}
 	}
 	return true
+}
+
+func createOptions(flags []CopyOption) map[CopyOption]bool {
+	opt := make(map[CopyOption]bool)
+	for _, o := range flags {
+		opt[o] = true
+	}
+	return opt
 }

--- a/copier_test.go
+++ b/copier_test.go
@@ -91,7 +91,7 @@ func TestCopyStruct(t *testing.T) {
 }
 
 func TestCopyFromStructToSlice(t *testing.T) {
-	user := User{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}
+	user := User{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}
 	employees := []Employee{}
 
 	if err := copier.Copy(employees, &user); err != nil && len(employees) != 0 {
@@ -127,7 +127,7 @@ func TestCopyFromStructToSlice(t *testing.T) {
 }
 
 func TestCopyFromSliceToSlice(t *testing.T) {
-	users := []User{User{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}, User{Name: "Jinzhu2", Age: 22, Role: "Dev", Notes: []string{"hello world", "hello"}}}
+	users := []User{User{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}, User{Name: "Jinzhu2", Nickname: "jinzhu", Age: 22, Role: "Dev", Notes: []string{"hello world", "hello"}}}
 	employees := []Employee{}
 
 	if copier.Copy(&employees, users); len(employees) != 2 {
@@ -186,4 +186,82 @@ func TestEmbedded(t *testing.T) {
 	if base.BaseField1 != 1 {
 		t.Error("Embedded fields not copied")
 	}
+}
+
+type A struct {
+	S       *string
+	Control string
+}
+
+type B struct {
+	S       string
+	Control string
+}
+
+type C struct {
+	S       *string
+	Control string
+}
+
+func TestEmptyValue(t *testing.T) {
+	b := &B{"", "foo"}
+	a := &A{}
+	copier.Copy(a, b)
+
+	if a.Control != "foo" {
+		t.Error("Incorrectly copied string")
+	} else if a.S != nil {
+		t.Error("Copied empty value field to pointer")
+	}
+}
+
+func TestNilPtoNiLP(t *testing.T) {
+	a := &A{}
+	c := &C{}
+	copier.Copy(a, c)
+	if a.S != nil {
+		t.Error("Did not copy nil pointer correctly")
+	}
+}
+
+func TestNilMap(t *testing.T) {
+	type Z struct {
+		M map[string]int
+		S string
+	}
+	type Y struct {
+		M map[string]int
+		S string
+	}
+	z := &Z{nil, "foo"}
+	y := &Y{}
+
+	copier.Copy(y, z)
+	if y.S != "foo" {
+		t.Error("Unable to copy string")
+	} else if y.M != nil {
+		t.Error("Uncorrectly copied zero value of map")
+	}
+
+}
+
+func TestNilSlice(t *testing.T) {
+	type Z struct {
+		Slice []string
+		S     string
+	}
+	type Y struct {
+		Slice []string
+		S     string
+	}
+	z := &Z{nil, "foo"}
+	y := &Y{}
+
+	copier.Copy(y, z)
+	if y.S != "foo" {
+		t.Error("Unable to copy string")
+	} else if y.Slice != nil {
+		t.Error("Uncorrectly copied zero value of slice")
+	}
+
 }

--- a/copier_test.go
+++ b/copier_test.go
@@ -263,5 +263,40 @@ func TestNilSlice(t *testing.T) {
 	} else if y.Slice != nil {
 		t.Error("Uncorrectly copied zero value of slice")
 	}
+}
 
+type ScannerType struct {
+	S string
+}
+
+func (s *ScannerType) Scan(src interface{}) error {
+	return fmt.Errorf("should not hit this")
+}
+
+func TestDisableScanner(t *testing.T) {
+	a := &ScannerType{}
+	b := &B{S: "foo"}
+	err := copier.Copy(a, b, copier.DISABLE_SCANNER)
+
+	if err != nil {
+		t.Errorf("called scan when disabled")
+	}
+
+	if a.S != b.S {
+		t.Errorf("Copied string incorrectly on ScannerInterface when scanner was disabled")
+	}
+}
+
+type JSONBType struct {
+	S []byte
+}
+
+func TestScanner(t *testing.T) {
+	a := &ScannerType{}
+	b := &JSONBType{S: []byte("foo")}
+	copier.Copy(a, &b)
+
+	if a.S != "foo" {
+		t.Error("Scanner was not called")
+	}
 }


### PR DESCRIPTION
After working with my branch a bit I think this is a cleaner implementation.

Ideally, we would make an instance of copier with the configuration.  But because we are using `gorm` we don't want package level flags having side affects. Now you disable scanner by doing things like:

`copier.Copy(to, from, copier.DISABLE_SCANNER)`