### PR TITLE
* When a field of the struct implements sql.Scanner, and Scanner.Scan…

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -171,7 +171,10 @@ func set(to, from reflect.Value) bool {
 		if from.Type().ConvertibleTo(to.Type()) {
 			to.Set(from.Convert(to.Type()))
 		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok {
-			scanner.Scan(from.Interface())
+			err := scanner.Scan(from.Interface())
+			if err != nil {
+				return false
+			}
 		} else if from.Kind() == reflect.Ptr {
 			return set(to, from.Elem())
 		} else {

--- a/copier_test.go
+++ b/copier_test.go
@@ -1,6 +1,8 @@
 package copier_test
 
 import (
+	"errors"
+
 	"reflect"
 	"testing"
 	"time"
@@ -216,5 +218,40 @@ func TestCopyFieldsWithSameNameButDifferentTypes(t *testing.T) {
 
 	if obj2.A != obj1.A {
 		t.Errorf("Field A should be copied")
+	}
+}
+
+type ScannerValue struct {
+	V int
+}
+
+func (s *ScannerValue) Scan(src interface{}) error {
+	return errors.New("I failed")
+}
+
+type ScannerStruct struct {
+	V *ScannerValue
+}
+
+type ScannerStructTo struct {
+	V *ScannerValue
+}
+
+func TestScanner(t *testing.T) {
+	s := &ScannerStruct{
+		V: &ScannerValue{
+			V: 12,
+		},
+	}
+
+	s2 := &ScannerStructTo{}
+
+	err := copier.Copy(s2, s)
+	if err != nil {
+		t.Error("Should not raise error")
+	}
+
+	if s.V.V != s2.V.V {
+		t.Errorf("Field V should be copied")
 	}
 }


### PR DESCRIPTION
… errors, the value is ignored and no error is issued.

Checking the error and returning false, the value is checked by other code, and gets copied correctly.