### PR TITLE
fix copy same struct with pointer fields

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -24,14 +24,15 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 		return
 	}
 
+	fromType := indirectType(from.Type())
+	toType := indirectType(to.Type())
+
 	// Just set it if possible to assign
-	if from.Type().AssignableTo(to.Type()) {
+	// And need to do copy anyway if the type is struct
+	if fromType.Kind() != reflect.Struct && from.Type().AssignableTo(to.Type()) {
 		to.Set(from)
 		return
 	}
-
-	fromType := indirectType(from.Type())
-	toType := indirectType(to.Type())
 
 	if fromType.Kind() != reflect.Struct || toType.Kind() != reflect.Struct {
 		return

--- a/copier_test.go
+++ b/copier_test.go
@@ -2,7 +2,6 @@ package copier_test
 
 import (
 	"errors"
-
 	"reflect"
 	"testing"
 	"time"
@@ -55,6 +54,10 @@ func checkEmployee(employee Employee, user User, t *testing.T, testCase string) 
 	if employee.Birthday != nil && user.Birthday == nil {
 		t.Errorf("%v: Birthday haven't been copied correctly.", testCase)
 	}
+	if employee.Birthday != nil && user.Birthday != nil &&
+		!employee.Birthday.Equal(*(user.Birthday)) {
+		t.Errorf("%v: Birthday haven't been copied correctly.", testCase)
+	}
 	if employee.Age != int64(user.Age) {
 		t.Errorf("%v: Age haven't been copied correctly.", testCase)
 	}
@@ -69,6 +72,21 @@ func checkEmployee(employee Employee, user User, t *testing.T, testCase string) 
 	}
 	if !reflect.DeepEqual(employee.Notes, user.Notes) {
 		t.Errorf("%v: Copy from slice doen't work", testCase)
+	}
+}
+
+func TestCopySameStructWithPointerField(t *testing.T) {
+	var fakeAge int32 = 12
+	var currentTime time.Time = time.Now()
+	user := &User{Birthday: &currentTime, Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin", Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
+	newUser := &User{}
+	copier.Copy(newUser, user)
+	if user.Birthday == newUser.Birthday {
+		t.Errorf("TestCopySameStructWithPointerField: copy Birthday failed since they need to have different address")
+	}
+
+	if user.FakeAge == newUser.FakeAge {
+		t.Errorf("TestCopySameStructWithPointerField: copy FakeAge failed since they need to have different address")
 	}
 }
 


### PR DESCRIPTION
fix a bug, when we're copying the same struct which has pointer fields, we'll get the same address of pointer field on original and new one after copy. After this fix, it will be ok!