### PR TITLE
add testCases for embered field test

### DIFF
--- a/copier_test.go
+++ b/copier_test.go
@@ -236,10 +236,11 @@ func TestCopyFromSliceToSlice2(t *testing.T) {
 	}
 }
 
-func TestEmbedded(t *testing.T) {
+func TestEmbeddedAndBase(t *testing.T) {
 	type Base struct {
 		BaseField1 int
 		BaseField2 int
+		User *User
 	}
 
 	type Embed struct {
@@ -255,10 +256,28 @@ func TestEmbedded(t *testing.T) {
 	embeded.EmbedField1 = 3
 	embeded.EmbedField2 = 4
 
+	user:=User{
+		Name:"testName",
+	}
+	embeded.User=&user
+
 	copier.Copy(&base, &embeded)
 
-	if base.BaseField1 != 1 {
+	if base.BaseField1 != 1 || base.User.Name!="testName"{
 		t.Error("Embedded fields not copied")
+	}
+
+	base.BaseField1=11
+	base.BaseField2=12
+	user1:=User{
+		Name:"testName1",
+	}
+	base.User=&user1
+
+	copier.Copy(&embeded,&base)
+
+	if embeded.BaseField1 != 11 || embeded.User.Name!="testName1" {
+		t.Error("base fields not copied")
 	}
 }
 


### PR DESCRIPTION
In my case, I copy struct with copier but the embered fields can't be displayed normally.
After be confused for a while , I found it's a problem with the graphql-go https://github.com/graphql-go/graphql/issues/170 (I am using graphql-go)

I think it is better to add some test cases for embered field test to make it more easier to confirm copier act correctly.
