### PR TITLE
Allow usage of pointers to generic type in Scan method for sql.Null* …

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -175,6 +175,7 @@ func set(to, from reflect.Value) bool {
 		if from.Type().ConvertibleTo(to.Type()) {
 			to.Set(from.Convert(to.Type()))
 		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok {
+			from = indirect(from)
 			err := scanner.Scan(from.Interface())
 			if err != nil {
 				return false

--- a/copier_test.go
+++ b/copier_test.go
@@ -1,6 +1,7 @@
 package copier_test
 
 import (
+	"database/sql"
 	"errors"
 	"reflect"
 	"testing"
@@ -240,7 +241,7 @@ func TestEmbeddedAndBase(t *testing.T) {
 	type Base struct {
 		BaseField1 int
 		BaseField2 int
-		User *User
+		User       *User
 	}
 
 	type Embed struct {
@@ -256,27 +257,27 @@ func TestEmbeddedAndBase(t *testing.T) {
 	embeded.EmbedField1 = 3
 	embeded.EmbedField2 = 4
 
-	user:=User{
-		Name:"testName",
+	user := User{
+		Name: "testName",
 	}
-	embeded.User=&user
+	embeded.User = &user
 
 	copier.Copy(&base, &embeded)
 
-	if base.BaseField1 != 1 || base.User.Name!="testName"{
+	if base.BaseField1 != 1 || base.User.Name != "testName" {
 		t.Error("Embedded fields not copied")
 	}
 
-	base.BaseField1=11
-	base.BaseField2=12
-	user1:=User{
-		Name:"testName1",
+	base.BaseField1 = 11
+	base.BaseField2 = 12
+	user1 := User{
+		Name: "testName1",
 	}
-	base.User=&user1
+	base.User = &user1
 
-	copier.Copy(&embeded,&base)
+	copier.Copy(&embeded, &base)
 
-	if embeded.BaseField1 != 11 || embeded.User.Name!="testName1" {
+	if embeded.BaseField1 != 11 || embeded.User.Name != "testName1" {
 		t.Error("base fields not copied")
 	}
 }
@@ -339,4 +340,39 @@ func TestScanner(t *testing.T) {
 	if s.V.V != s2.V.V {
 		t.Errorf("Field V should be copied")
 	}
+}
+
+func TestScanFromPtrToSqlNullable(t *testing.T) {
+
+	var (
+		from struct {
+			S    string
+			Sptr *string
+		}
+
+		to struct {
+			S    sql.NullString
+			Sptr sql.NullString
+		}
+
+		s string
+	)
+
+	s = "test"
+	from.S = s
+	from.Sptr = &s
+
+	err := copier.Copy(&to, from)
+	if err != nil {
+		t.Error("Should not raise error")
+	}
+
+	if to.S.String != from.S {
+		t.Errorf("Field S should be copied")
+	}
+
+	if to.Sptr.String != *from.Sptr {
+		t.Errorf("Field Sptr should be copied")
+	}
+
 }


### PR DESCRIPTION
```go
type Request struct {
	Name      *string // <--- not copying properly
	Num       int // <--- not copying properly
	CreatedAt *time.Time // <--- not copying properly
	UpdatedAt sql.NullTime
}

type Model struct {
	Name      sql.NullString
	Num       sql.NullInt32
	CreatedAt sql.NullTime
	UpdatedAt sql.NullTime
}
```

These fields don't copies.
One new line resolve this issue.