### PR TITLE
<feat>: add CopyByTag  extend

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -128,6 +128,150 @@ func Copy(toValue interface{}, fromValue interface{}) (err error) {
 	return
 }
 
+// Copy copy things By Tag
+func CopyByTag(toValue interface{}, fromValue interface{}, tag string) (err error) {
+	if tag == "" {
+		return Copy(toValue, fromValue)
+	}
+	var (
+		isSlice bool
+		amount  = 1
+		from    = indirect(reflect.ValueOf(fromValue))
+		to      = indirect(reflect.ValueOf(toValue))
+	)
+
+	if !to.CanAddr() {
+		return errors.New("copy to value is unaddressable")
+	}
+
+	// Return is from value is invalid
+	if !from.IsValid() {
+		return
+	}
+
+	fromType := indirectType(from.Type())
+	toType := indirectType(to.Type())
+
+	// Just set it if possible to assign
+	// And need to do copy anyway if the type is struct
+	if fromType.Kind() != reflect.Struct && from.Type().AssignableTo(to.Type()) {
+		to.Set(from)
+		return
+	}
+
+	if fromType.Kind() != reflect.Struct || toType.Kind() != reflect.Struct {
+		return
+	}
+
+	if to.Kind() == reflect.Slice {
+		isSlice = true
+		if from.Kind() == reflect.Slice {
+			amount = from.Len()
+		}
+	}
+	//get fields
+	fromTypeFields := deepFields(fromType)
+	toTypeFields := deepFields(toType)
+
+	//generate to map  tag => fieldName
+	ToTagNameMapFieldName := make(map[string]string, len(toTypeFields))
+	for i := 0; i < len(toTypeFields); i++ {
+		var tTagName = GetTag(toTypeFields[i], tag)
+		ToTagNameMapFieldName[tTagName] = toTypeFields[i].Name
+	}
+
+	for i := 0; i < amount; i++ {
+		var dest, source reflect.Value
+
+		if isSlice {
+			// source
+			if from.Kind() == reflect.Slice {
+				source = indirect(from.Index(i))
+			} else {
+				source = indirect(from)
+			}
+			// dest
+			dest = indirect(reflect.New(toType).Elem())
+		} else {
+			source = indirect(from)
+			dest = indirect(to)
+		}
+
+		// check source
+		if source.IsValid() {
+			//fmt.Printf("%#v", fromTypeFields)
+			// Copy from field to field or method
+			for _, field := range fromTypeFields {
+				var fromFieldName = field.Name
+				var fromTagName = GetTag(field, tag)
+
+				if fromField := source.FieldByName(fromFieldName); fromField.IsValid() {
+					// has field
+					var toFieldName string
+					var toField reflect.Value
+
+					if mapV, ok := ToTagNameMapFieldName[fromTagName]; ok {
+						toFieldName = mapV
+						toField = dest.FieldByName(toFieldName)
+					}
+
+					if toField.IsValid() {
+						if toField.CanSet() {
+							if !set(toField, fromField) {
+								if err := CopyByTag(toField.Addr().Interface(), fromField.Interface(), tag); err != nil {
+									return err
+								}
+							}
+						}
+					} else {
+						// try to set to method
+						var toMethod reflect.Value
+						if dest.CanAddr() {
+							toMethod = dest.Addr().MethodByName(fromTagName)
+						} else {
+							toMethod = dest.MethodByName(fromTagName)
+						}
+
+						if toMethod.IsValid() && toMethod.Type().NumIn() == 1 && fromField.Type().AssignableTo(toMethod.Type().In(0)) {
+							toMethod.Call([]reflect.Value{fromField})
+						}
+					}
+				}
+			}
+
+			// Copy from method to field
+			for _, field := range toTypeFields {
+				var toFieldName = field.Name
+				var toTagName = GetTag(field, tag)
+
+				var fromMethod reflect.Value
+				if source.CanAddr() {
+					fromMethod = source.Addr().MethodByName(toTagName)
+				} else {
+					fromMethod = source.MethodByName(toTagName)
+				}
+
+				if fromMethod.IsValid() && fromMethod.Type().NumIn() == 0 && fromMethod.Type().NumOut() == 1 {
+					if toField := dest.FieldByName(toFieldName); toField.IsValid() && toField.CanSet() {
+						values := fromMethod.Call([]reflect.Value{})
+						if len(values) >= 1 {
+							set(toField, values[0])
+						}
+					}
+				}
+			}
+		}
+		if isSlice {
+			if dest.Addr().Type().AssignableTo(to.Type().Elem()) {
+				to.Set(reflect.Append(to, dest.Addr()))
+			} else if dest.Type().AssignableTo(to.Type().Elem()) {
+				to.Set(reflect.Append(to, dest))
+			}
+		}
+	}
+	return
+}
+
 func deepFields(reflectType reflect.Type) []reflect.StructField {
 	var fields []reflect.StructField
 
@@ -161,6 +305,10 @@ func indirectType(reflectType reflect.Type) reflect.Type {
 
 func set(to, from reflect.Value) bool {
 	if from.IsValid() {
+		if from.Kind() == reflect.Struct {
+			return false
+		}
+
 		if to.Kind() == reflect.Ptr {
 			//set `to` to nil if from is nil
 			if from.Kind() == reflect.Ptr && from.IsNil() {
@@ -186,4 +334,12 @@ func set(to, from reflect.Value) bool {
 		}
 	}
 	return true
+}
+
+func GetTag(field reflect.StructField, tag string) string {
+	if tagName, ok := field.Tag.Lookup(tag); ok {
+		return tagName
+	} else {
+		return field.Name
+	}
 }

--- a/copier_benchmark_tag_test.go
+++ b/copier_benchmark_tag_test.go
@@ -1,0 +1,47 @@
+package copier_test
+
+import (
+	"copier"
+	"encoding/json"
+	"testing"
+)
+
+func BenchmarkCopyStructTag(b *testing.B) {
+	var fakeAge int32 = 12
+	user := UserTag{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin",
+		Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
+	for x := 0; x < b.N; x++ {
+		copier.CopyByTag(&EmployeeTag{}, &user, "mson")
+	}
+}
+
+func BenchmarkNamaCopyTag(b *testing.B) {
+	var fakeAge int32 = 12
+	user := UserTag{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin",
+		Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
+	for x := 0; x < b.N; x++ {
+		employee := &EmployeeTag{
+			Name:      user.Name,
+			Nickname:  &user.Nickname,
+			Age:       int64(user.Age),
+			FakeAge:   int(*user.FakeAge),
+			DoubleAge: user.DoubleAge_int32(),
+			Notes:     user.Notes,
+		}
+		employee.Role_string(user.Role)
+	}
+}
+
+func BenchmarkJsonMarshalCopyTag(b *testing.B) {
+	var fakeAge int32 = 12
+	user := UserTag{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin",
+		Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
+	for x := 0; x < b.N; x++ {
+		data, _ := json.Marshal(user)
+		var employee EmployeeTag
+		json.Unmarshal(data, &employee)
+
+		employee.DoubleAge = user.DoubleAge_int32()
+		employee.Role_string(user.Role)
+	}
+}

--- a/copier_benchmark_tag_test.go
+++ b/copier_benchmark_tag_test.go
@@ -1,8 +1,8 @@
 package copier_test
 
 import (
-	"copier"
 	"encoding/json"
+	"github.com/ybzhanghx/copier"
 	"testing"
 )
 

--- a/copier_tag_test.go
+++ b/copier_tag_test.go
@@ -1,0 +1,369 @@
+package copier_test
+
+import (
+	"copier"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+
+)
+
+type UserTag struct {
+	Name     string     `mson:"Name_string"`
+	Birthday *time.Time `mson:"Birthday_time_Time"`
+	Nickname string     `mson:"Nickname_string"`
+	Role     string     `mson:"Role_string"`
+	Age      int32      `mson:"Age_int32"`
+	FakeAge  *int32     `mson:"FakeAge_int32"`
+	Notes    []string   `mson:"Notes_string_slice"`
+	flags    []byte     `mson:"flags_byte_slice"`
+}
+
+func (user UserTag) DoubleAge_int32() int32 {
+	return 2 * user.Age
+}
+
+type EmployeeTag struct {
+	Name      string     `mson:"Name_string"`
+	Birthday  *time.Time `mson:"Birthday_time_Time"`
+	Nickname  *string    `mson:"Nickname_string"`
+	Age       int64      `mson:"Age_int64"`
+	FakeAge   int        `mson:"FakeAge_int"`
+	EmployeeID int64     `mson:"EmployeeId_int64"`
+	DoubleAge int32      `mson:"DoubleAge_int32"`
+	SuperRule string     `mson:"SuperRule_string"`
+	Notes     []string   `mson:"Notes_string_slice"`
+	flags     []byte     `mson:"flags_byte_slice"`
+}
+
+func (employee *EmployeeTag) FakeAge_int32(FakeAge *int32) {
+	if FakeAge == nil{
+		return
+	}
+	employee.FakeAge = int(*FakeAge)
+}
+
+func (employee *EmployeeTag) Age_int32(age int32) {
+	employee.Age = int64(age)
+}
+
+func (employee *EmployeeTag) Role_string(role string) {
+	employee.SuperRule = "Super " + role
+}
+
+func checkEmployeeTag(employee EmployeeTag, user UserTag, t *testing.T, testCase string) {
+	if employee.Name != user.Name {
+		t.Errorf("%v: Name haven't been copied correctly.", testCase)
+	}
+	if employee.Nickname == nil || *employee.Nickname != user.Nickname {
+		t.Errorf("%v: NickName haven't been copied correctly.", testCase)
+	}
+	if employee.Birthday == nil && user.Birthday != nil {
+		t.Errorf("%v: Birthday haven't been copied correctly.", testCase)
+	}
+	if employee.Birthday != nil && user.Birthday == nil {
+		t.Errorf("%v: Birthday haven't been copied correctly.", testCase)
+	}
+	if employee.Birthday != nil && user.Birthday != nil &&
+		!employee.Birthday.Equal(*(user.Birthday)) {
+		t.Errorf("%v: Birthday haven't been copied correctly.", testCase)
+	}
+	if employee.Age != int64(user.Age) {
+		t.Errorf("%v: Age haven't been copied correctly.", testCase)
+	}
+	if user.FakeAge != nil && employee.FakeAge != int(*user.FakeAge) {
+		t.Errorf("%v: FakeAge haven't been copied correctly.", testCase)
+	}
+	if employee.DoubleAge != user.DoubleAge_int32() {
+		t.Errorf("%v: Copy from method doesn't work", testCase)
+	}
+	if employee.SuperRule != "Super "+user.Role {
+		t.Errorf("%v: Copy to method doesn't work", testCase)
+	}
+	if !reflect.DeepEqual(employee.Notes, user.Notes) {
+		t.Errorf("%v: Copy from slice doen't work", testCase)
+	}
+}
+
+func TestCopySameStructWithPointerFieldTag(t *testing.T) {
+	var fakeAge int32 = 12
+	var currentTime time.Time = time.Now()
+	user := &UserTag{Birthday: &currentTime, Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge,
+		Role: "Admin", Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
+	newUser := &UserTag{}
+	copier.CopyByTag(newUser, user,"mson")
+	if user.Birthday == newUser.Birthday {
+		t.Errorf("TestCopySameStructWithPointerField: copy Birthday failed since they need to have different address")
+	}
+
+	if user.FakeAge == newUser.FakeAge {
+		t.Errorf("TestCopySameStructWithPointerField: copy FakeAge failed since they need to have different address")
+	}
+}
+
+func checkEmployeeTag2(employee EmployeeTag, user *UserTag, t *testing.T, testCase string) {
+	if user == nil {
+		if employee.Name != "" || employee.Nickname != nil || employee.Birthday != nil || employee.Age != 0 ||
+			employee.DoubleAge != 0 || employee.FakeAge != 0 || employee.SuperRule != "" || employee.Notes != nil {
+			t.Errorf("%v : employee should be empty", testCase)
+		}
+		return
+	}
+
+	checkEmployeeTag(employee, *user, t, testCase)
+}
+
+func TestCopyStructTag(t *testing.T) {
+	var fakeAge int32 = 12
+	user := UserTag{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin",
+		Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
+	employee := EmployeeTag{}
+
+	if err := copier.CopyByTag(employee, &user,"mson"); err == nil {
+		t.Errorf("Copy to unaddressable value should get error")
+	}
+
+	copier.CopyByTag(&employee, &user,"mson")
+	checkEmployeeTag(employee, user, t, "Copy From Ptr To Ptr")
+
+	employee2 := EmployeeTag{}
+	copier.CopyByTag(&employee2, user,"mson")
+	checkEmployeeTag(employee2, user, t, "Copy From Struct To Ptr")
+
+	employee3 := EmployeeTag{}
+	ptrToUser := &user
+	copier.CopyByTag(&employee3, &ptrToUser,"mson")
+	checkEmployeeTag(employee3, user, t, "Copy From Double Ptr To Ptr")
+
+	employee4 := &EmployeeTag{}
+	copier.CopyByTag(&employee4, user,"mson")
+	checkEmployeeTag(*employee4, user, t, "Copy From Ptr To Double Ptr")
+}
+
+func TestCopyFromStructToSliceTag(t *testing.T) {
+	user := UserTag{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}
+	employees := []EmployeeTag{}
+
+	if err := copier.CopyByTag(employees, &user,"mson"); err != nil && len(employees) != 0 {
+		t.Errorf("Copy to unaddressable value should get error")
+	}
+
+	if copier.CopyByTag(&employees, &user,"mson"); len(employees) != 1 {
+		t.Errorf("Should only have one elem when copy struct to slice")
+	} else {
+		checkEmployeeTag(employees[0], user, t, "Copy From Struct To Slice Ptr")
+	}
+
+	employees2 := &[]EmployeeTag{}
+	if copier.CopyByTag(&employees2, user,"mson"); len(*employees2) != 1 {
+		t.Errorf("Should only have one elem when copy struct to slice")
+	} else {
+		checkEmployeeTag((*employees2)[0], user, t, "Copy From Struct To Double Slice Ptr")
+	}
+
+	employees3 := []*EmployeeTag{}
+	if copier.CopyByTag(&employees3, user,"mson"); len(employees3) != 1 {
+		t.Errorf("Should only have one elem when copy struct to slice")
+	} else {
+		checkEmployeeTag(*(employees3[0]), user, t, "Copy From Struct To Ptr Slice Ptr")
+	}
+
+	employees4 := &[]*EmployeeTag{}
+	if copier.CopyByTag(&employees4, user,"mson"); len(*employees4) != 1 {
+		t.Errorf("Should only have one elem when copy struct to slice")
+	} else {
+		checkEmployeeTag(*((*employees4)[0]), user, t, "Copy From Struct To Double Ptr Slice Ptr")
+	}
+}
+
+func TestCopyFromSliceToSliceTag(t *testing.T) {
+	users := []UserTag{UserTag{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}},
+		UserTag{Name: "Jinzhu2", Age: 22, Role: "Dev", Notes: []string{"hello world", "hello"}}}
+	employees := []EmployeeTag{}
+
+	if copier.CopyByTag(&employees, users,"mson"); len(employees) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag(employees[0], users[0], t, "Copy From Slice To Slice Ptr @ 1")
+		checkEmployeeTag(employees[1], users[1], t, "Copy From Slice To Slice Ptr @ 2")
+	}
+
+	employees2 := &[]EmployeeTag{}
+	if copier.CopyByTag(&employees2, &users,"mson"); len(*employees2) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag((*employees2)[0], users[0], t, "Copy From Slice Ptr To Double Slice Ptr @ 1")
+		checkEmployeeTag((*employees2)[1], users[1], t, "Copy From Slice Ptr To Double Slice Ptr @ 2")
+	}
+
+	employees3 := []*EmployeeTag{}
+	if copier.CopyByTag(&employees3, users,"mson"); len(employees3) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag(*(employees3[0]), users[0], t, "Copy From Slice To Ptr Slice Ptr @ 1")
+		checkEmployeeTag(*(employees3[1]), users[1], t, "Copy From Slice To Ptr Slice Ptr @ 2")
+	}
+
+	employees4 := &[]*EmployeeTag{}
+	if copier.CopyByTag(&employees4, users,"mson"); len(*employees4) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag(*((*employees4)[0]), users[0], t, "Copy From Slice Ptr To Double Ptr Slice Ptr @ 1")
+		checkEmployeeTag(*((*employees4)[1]), users[1], t, "Copy From Slice Ptr To Double Ptr Slice Ptr @ 2")
+	}
+}
+
+func TestCopyFromSliceToSliceTag2(t *testing.T) {
+	users := []*UserTag{{Name: "Jinzhu", Age: 18, Role: "Admin", Notes: []string{"hello world"}}, nil}
+	employees := []EmployeeTag{}
+
+	if copier.CopyByTag(&employees, users,"mson"); len(employees) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag2(employees[0], users[0], t, "Copy From Slice To Slice Ptr @ 1")
+		checkEmployeeTag2(employees[1], users[1], t, "Copy From Slice To Slice Ptr @ 2")
+	}
+
+	employees2 := &[]EmployeeTag{}
+	if copier.CopyByTag(&employees2, &users,"mson"); len(*employees2) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag2((*employees2)[0], users[0], t, "Copy From Slice Ptr To Double Slice Ptr @ 1")
+		checkEmployeeTag2((*employees2)[1], users[1], t, "Copy From Slice Ptr To Double Slice Ptr @ 2")
+	}
+
+	employees3 := []*EmployeeTag{}
+	if copier.CopyByTag(&employees3, users,"mson"); len(employees3) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag2(*(employees3[0]), users[0], t, "Copy From Slice To Ptr Slice Ptr @ 1")
+		checkEmployeeTag2(*(employees3[1]), users[1], t, "Copy From Slice To Ptr Slice Ptr @ 2")
+	}
+
+	employees4 := &[]*EmployeeTag{}
+	if copier.CopyByTag(&employees4, users,"mson"); len(*employees4) != 2 {
+		t.Errorf("Should have two elems when copy slice to slice")
+	} else {
+		checkEmployeeTag2(*((*employees4)[0]), users[0], t, "Copy From Slice Ptr To Double Ptr Slice Ptr @ 1")
+		checkEmployeeTag2(*((*employees4)[1]), users[1], t, "Copy From Slice Ptr To Double Ptr Slice Ptr @ 2")
+	}
+}
+
+func TestEmbeddedAndBaseTag(t *testing.T) {
+	type Base struct {
+		BaseField1 int `mson:"BaseField1_int"`
+		BaseField2 int `mson:"baseField2_int"`
+		User *UserTag     `mson:"User_User"`
+	}
+
+	type Embed struct {
+		EmbedField1 int `mson:"EmbedField1_int"`
+		EmbedField2 int `mson:"EmbedField2_int"`
+		Base
+	}
+
+	base := Base{}
+	embeded := Embed{}
+	embeded.BaseField1 = 1
+	embeded.BaseField2 = 2
+	embeded.EmbedField1 = 3
+	embeded.EmbedField2 = 4
+
+	user:=UserTag{
+		Name:"testName",
+	}
+	embeded.User=&user
+
+	copier.CopyByTag(&base, &embeded,"mson")
+
+	if base.BaseField1 != 1 || base.User.Name!="testName"{
+		t.Error("Embedded fields not copied")
+	}
+
+	base.BaseField1=11
+	base.BaseField2=12
+	user1:=UserTag{
+		Name:"testName1",
+	}
+	base.User=&user1
+
+	copier.CopyByTag(&embeded,&base,"mson")
+
+	if embeded.BaseField1 != 11 || embeded.User.Name!="testName1" {
+		t.Error("base fields not copied")
+	}
+}
+
+type structSameName1Tag struct {
+	A string    `mson:"A_string"`
+	B int64     `mson:"B_int64"`
+	C time.Time `mson:"C_time_Time"`
+}
+
+type structSameName2Tag struct {
+	A string    `mson:"A_string"`
+	B time.Time `mson:"B_time_Time"`
+	C int64     `mson:"C_int64"`
+}
+
+func (s *structSameName2Tag) C_time_Time(t time.Time){
+	s.C = t.Unix()
+}
+func (s *structSameName2Tag) B_int64(B int64){
+	s.B = time.Unix(B,0)
+}
+func TestCopyFieldsWithSameNameButDifferentTypesTag(t *testing.T) {
+	obj1 := structSameName1Tag{A: "123", B: 2, C: time.Now()}
+	obj2 := &structSameName2Tag{}
+	err := copier.CopyByTag(obj2, &obj1,"mson")
+	if err != nil {
+		t.Error("Should not raise error")
+	}
+
+	if obj2.A != obj1.A {
+		t.Errorf("Field A should be copied")
+	}
+	if obj2.B.Unix() != obj1.B{
+		t.Errorf("Field B should be copied")
+	}
+	if obj2.C != obj1.C.Unix(){
+		t.Errorf("Field C should be copied")
+	}
+}
+
+type ScannerValueTag struct {
+	V int  `json:"mson:"V_int"`
+}
+
+func (s *ScannerValue) ScanTag(src interface{}) error {
+	return errors.New("I failed")
+}
+
+type ScannerStructTag struct {
+	V *ScannerValueTag   `mson:"V_ScannerValueTag"`
+}
+
+type ScannerStructToTag struct {
+	V *ScannerValueTag `mson:"V_ScannerValueTag"`
+}
+
+func TestScannerTag(t *testing.T) {
+	s := &ScannerStructTag{
+		V: &ScannerValueTag{
+			V: 12,
+		},
+	}
+
+	s2 := &ScannerStructToTag{}
+
+	err := copier.CopyByTag(s2, s,"mson")
+	if err != nil {
+		t.Error("Should not raise error")
+	}
+
+	if s.V.V != s2.V.V {
+		t.Errorf("Field V should be copied")
+	}
+}

--- a/copier_tag_test.go
+++ b/copier_tag_test.go
@@ -1,13 +1,11 @@
 package copier_test
 
 import (
-	"copier"
 	"errors"
+	"github.com/ybzhanghx/copier"
 	"reflect"
 	"testing"
 	"time"
-
-
 )
 
 type UserTag struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module copier
+module github.com/ybzhanghx/copier
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module copier
+
+go 1.15
+
+require github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a


### PR DESCRIPTION
copy field by specifying a tag.
This will make field type conversion very easy.
Allows  to copy fields of different types even with different names.

# example
```go
type structSameName1Tag struct {
	Aa string    `mson:"A_string"`
	B int64     `mson:"B_int64"`
	C time.Time `mson:"C_time_Time"`
}

type structSameName2Tag struct {
	A string    `mson:"A_string"`
	B time.Time `mson:"B_time_Time"`
	C int64     `mson:"C_int64"`
}

func (s *structSameName2Tag) C_time_Time(t time.Time){
	s.C = t.Unix()
}
func (s *structSameName2Tag) B_int64(B int64){
	s.B = time.Unix(B,0)
}
func TestCopyFieldsWithSameNameButDifferentTypesTag(t *testing.T) {
	obj1 := structSameName1Tag{Aa: "123", B: 2, C: time.Now()}
	obj2 := &structSameName2Tag{}
	err := copier.CopyByTag(obj2, &obj1,"mson")
	if err != nil {
		t.Error("Should not raise error")
	}

	if obj2.A != obj1.Aa {
		t.Errorf("Field A should be copied")
	}
	if obj2.B.Unix() != obj1.B{
		t.Errorf("Field B should be copied")
	}
	if obj2.C != obj1.C.Unix(){
		t.Errorf("Field C should be copied")
	}
}
```

