### PR TITLE
Add tags to enforce or ignore copying of fields

### DIFF
--- a/copier_tags_test.go
+++ b/copier_tags_test.go
@@ -1,0 +1,46 @@
+package copier
+
+import "testing"
+
+type EmployeeTags struct {
+	Name    string `copier:"must"`
+	DOB     string
+	Address string
+	ID      int `copier:"-"`
+}
+
+type User1 struct {
+	Name    string
+	DOB     string
+	Address string
+	ID      int
+}
+
+type User2 struct {
+	DOB     string
+	Address string
+	ID      int
+}
+
+func TestCopyTagIgnore(t *testing.T) {
+	employee := EmployeeTags{ID: 100}
+	user := User1{Name: "Dexter Ledesma", DOB: "1 November, 1970", Address: "21 Jump Street", ID: 12345}
+	Copy(&employee, user)
+	if employee.ID == user.ID {
+		t.Error("Was not expected to copy IDs")
+	}
+	if employee.ID != 100 {
+		t.Error("Original ID was overwritten")
+	}
+}
+
+func TestCopyTagMust(t *testing.T) {
+	employee := &EmployeeTags{}
+	user := &User2{DOB: "1 January 1970"}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected a panic.")
+		}
+	}()
+	Copy(employee, user)
+}


### PR DESCRIPTION
This change introduces struct tags "must", "-" and "nopanic". These tags
are used in the destination struct to enforce field copying or ignore
field copying.

The behaviours that are invoked by tags are...

- "must": `copier:"must"` When added to a destination struct and the field was not
    copied by Copy, "must" will either trigger a panic in Copy or if the
    "nopanic" flag is set will return an error.

- "-": `copier:"-"` When added to a destination struct, explicitly ignore copying
   a field.

-  "nopanic": `copier:"must,nopanic"` When Copy is called and nopanic is set in conjunction
   with "must", Copy will return an error.