### PR TITLE
Add support for copying to an interface using source type and allow deep copy on map field

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -64,6 +64,14 @@ func copy(toValue interface{}, fromValue interface{}, ignoreEmpty, deepCopy bool
 	fromType := indirectType(from.Type())
 	toType := indirectType(to.Type())
 
+	if fromType.Kind() == reflect.Interface {
+		fromType = reflect.TypeOf(from.Interface())
+	}
+
+	if toType.Kind() == reflect.Interface {
+		toType = reflect.TypeOf(to.Interface())
+	}
+
 	// Just set it if possible to assign
 	// And need to do copy anyway if the type is struct
 	if fromType.Kind() != reflect.Struct && from.Type().AssignableTo(to.Type()) {
@@ -121,6 +129,13 @@ func copy(toValue interface{}, fromValue interface{}, ignoreEmpty, deepCopy bool
 		} else {
 			source = indirect(from)
 			dest = indirect(to)
+		}
+
+		destKind := dest.Kind()
+		initDest := false
+		if destKind == reflect.Interface {
+			initDest = true
+			dest = indirect(reflect.New(toType))
 		}
 
 		// Get tag options
@@ -203,6 +218,9 @@ func copy(toValue interface{}, fromValue interface{}, ignoreEmpty, deepCopy bool
 				to.Set(reflect.Append(to, dest))
 			}
 		}
+		if initDest {
+			to.Set(dest)
+		}
 		err = checkBitFlags(tagBitFlags)
 	}
 	return
@@ -261,8 +279,16 @@ func set(to, from reflect.Value, deepCopy bool) bool {
 			to = to.Elem()
 		}
 
-		if deepCopy && to.Kind() == reflect.Struct {
-			return false
+		if deepCopy {
+			toKind := to.Kind()
+			if toKind == reflect.Interface && to.IsNil() {
+				to.Set(reflect.New(reflect.TypeOf(from.Interface())).Elem())
+				toKind = reflect.TypeOf(to.Interface()).Kind()
+			}
+
+			if toKind == reflect.Struct {
+				return false
+			}
 		}
 
 		if from.Type().ConvertibleTo(to.Type()) {

--- a/copier.go
+++ b/copier.go
@@ -74,7 +74,7 @@ func copy(toValue interface{}, fromValue interface{}, ignoreEmpty, deepCopy bool
 
 	// Just set it if possible to assign
 	// And need to do copy anyway if the type is struct
-	if fromType.Kind() != reflect.Struct && from.Type().AssignableTo(to.Type()) {
+	if fromType.Kind() != reflect.Struct && (!deepCopy || fromType.Kind() != reflect.Map) && from.Type().AssignableTo(to.Type()) {
 		to.Set(from)
 		return
 	}
@@ -286,7 +286,7 @@ func set(to, from reflect.Value, deepCopy bool) bool {
 				toKind = reflect.TypeOf(to.Interface()).Kind()
 			}
 
-			if toKind == reflect.Struct {
+			if toKind == reflect.Struct || toKind == reflect.Map {
 				return false
 			}
 		}

--- a/copier_test.go
+++ b/copier_test.go
@@ -558,6 +558,68 @@ func TestStructField(t *testing.T) {
 	})
 }
 
+func TestInterface(t *testing.T) {
+	type Inner struct {
+		IntPtr *int
+	}
+
+	type Outer struct {
+		Inner Inner
+	}
+
+	type DriverOptions struct {
+		GenOptions interface{}
+	}
+
+	t.Run("Should work without deepCopy", func(t *testing.T) {
+		intVal := 5
+		outer := Outer{
+			Inner: Inner{
+				IntPtr: &intVal,
+			},
+		}
+		from := DriverOptions{
+			GenOptions: outer,
+		}
+		to := DriverOptions{}
+		if err := Copy(&to, from); nil != err {
+			t.Errorf("Unexpected error: %v", err)
+			return
+		}
+
+		*to.GenOptions.(Outer).Inner.IntPtr = 6
+
+		if to.GenOptions.(Outer).Inner.IntPtr != from.GenOptions.(Outer).Inner.IntPtr {
+			t.Errorf("should be the same")
+		}
+	})
+
+	t.Run("Should work with deepCopy", func(t *testing.T) {
+		intVal := 5
+		outer := Outer{
+			Inner: Inner{
+				IntPtr: &intVal,
+			},
+		}
+		from := DriverOptions{
+			GenOptions: outer,
+		}
+		to := DriverOptions{}
+		if err := CopyWithOption(&to, &from, copier.Option{
+			DeepCopy: true,
+		}); nil != err {
+			t.Errorf("Unexpected error: %v", err)
+			return
+		}
+
+		*to.GenOptions.(Outer).Inner.IntPtr = 6
+
+		if to.GenOptions.(Outer).Inner.IntPtr == from.GenOptions.(Outer).Inner.IntPtr {
+			t.Errorf("should be different")
+		}
+	})
+}
+
 type someStruct struct {
 	IntField  int
 	UIntField uint64

--- a/copier_test.go
+++ b/copier_test.go
@@ -558,6 +558,75 @@ func TestStructField(t *testing.T) {
 	})
 }
 
+func TestMapInterface(t *testing.T) {
+	type Inner struct {
+		IntPtr          *int
+		unexportedField string
+	}
+
+	type Outer struct {
+		Inner Inner
+	}
+
+	type DriverOptions struct {
+		GenOptions map[string]interface{}
+	}
+
+	t.Run("Should work without deepCopy", func(t *testing.T) {
+		intVal := 5
+		outer := Outer{
+			Inner: Inner{
+				IntPtr:          &intVal,
+				unexportedField: "hello",
+			},
+		}
+		from := DriverOptions{
+			GenOptions: map[string]interface{}{
+				"key": outer,
+			},
+		}
+		to := DriverOptions{}
+		if err := copier.Copy(&to, &from); nil != err {
+			t.Errorf("Unexpected error: %v", err)
+			return
+		}
+
+		*to.GenOptions["key"].(Outer).Inner.IntPtr = 6
+
+		if to.GenOptions["key"].(Outer).Inner.IntPtr != from.GenOptions["key"].(Outer).Inner.IntPtr {
+			t.Errorf("should be the same")
+		}
+	})
+
+	t.Run("Should work with deepCopy", func(t *testing.T) {
+		intVal := 5
+		outer := Outer{
+			Inner: Inner{
+				IntPtr:          &intVal,
+				unexportedField: "Hello",
+			},
+		}
+		from := DriverOptions{
+			GenOptions: map[string]interface{}{
+				"key": outer,
+			},
+		}
+		to := DriverOptions{}
+		if err := copier.CopyWithOption(&to, &from, copier.Option{
+			DeepCopy: true,
+		}); nil != err {
+			t.Errorf("Unexpected error: %v", err)
+			return
+		}
+
+		*to.GenOptions["key"].(Outer).Inner.IntPtr = 6
+
+		if to.GenOptions["key"].(Outer).Inner.IntPtr == from.GenOptions["key"].(Outer).Inner.IntPtr {
+			t.Errorf("should be different")
+		}
+	})
+}
+
 func TestInterface(t *testing.T) {
 	type Inner struct {
 		IntPtr *int

--- a/copier_test.go
+++ b/copier_test.go
@@ -582,7 +582,7 @@ func TestInterface(t *testing.T) {
 			GenOptions: outer,
 		}
 		to := DriverOptions{}
-		if err := Copy(&to, from); nil != err {
+		if err := copier.Copy(&to, from); nil != err {
 			t.Errorf("Unexpected error: %v", err)
 			return
 		}
@@ -605,7 +605,7 @@ func TestInterface(t *testing.T) {
 			GenOptions: outer,
 		}
 		to := DriverOptions{}
-		if err := CopyWithOption(&to, &from, copier.Option{
+		if err := copier.CopyWithOption(&to, &from, copier.Option{
 			DeepCopy: true,
 		}); nil != err {
 			t.Errorf("Unexpected error: %v", err)


### PR DESCRIPTION
Closes #57 

Change details:

Add support for copying to an interface using source type
Add support for deep copy on map field
Add more tests for this use case