### PR TITLE
[fix] #78 Note that a copy was made after successful copy

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -223,11 +223,10 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 								if err := copier(toField.Addr().Interface(), fromField.Interface(), opt); err != nil {
 									return err
 								}
-							} else {
-								if fieldFlags != 0 {
-									// Note that a copy was made
-									tagBitFlags[name] = fieldFlags | hasCopied
-								}
+							}
+							if fieldFlags != 0 {
+								// Note that a copy was made
+								tagBitFlags[name] = fieldFlags | hasCopied
 							}
 						}
 					} else {


### PR DESCRIPTION
This should fix issue #78 

It's make sense to do `tagBitFlags[name] = fieldFlags | hasCopied` also in case where call to `copier` juste above success.