### PR TITLE
[fix] #80 check if field is existsing before access

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -193,6 +193,10 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 					destFieldNotSet := false
 					if f, ok := dest.Type().FieldByName(name); ok {
 						for idx, x := range f.Index {
+							if x >= dest.NumField() {
+								continue
+							}
+
 							destFieldKind := dest.Field(x).Kind()
 							if destFieldKind != reflect.Ptr {
 								continue


### PR DESCRIPTION
This should fix #80 

`destFieldKind := dest.Field(x).Kind()` will panic if `x >= dest.NumField()`