### PR TITLE
Copy un-exported struct fields in DeepCopy

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -372,10 +372,10 @@ func deepFields(reflectType reflect.Type) []reflect.StructField {
 			// field name. It is empty for upper case (exported) field names.
 			// See https://golang.org/ref/spec#Uniqueness_of_identifiers
 			if v.PkgPath == "" {
+				fields = append(fields, v)
 				if v.Anonymous {
+					// also consider fields of anonymous fields as fields of the root
 					fields = append(fields, deepFields(v.Type)...)
-				} else {
-					fields = append(fields, v)
 				}
 			}
 		}

--- a/copier_test.go
+++ b/copier_test.go
@@ -1453,3 +1453,20 @@ func TestDeepCopySimpleTime(t *testing.T) {
 		t.Errorf("to (%v) value should equal from (%v) value", to, from)
 	}
 }
+
+type TimeWrapper struct{
+	time.Time
+}
+
+func TestDeepCopyAnonymousFieldTime(t *testing.T) {
+	from := TimeWrapper{time.Now()}
+	to := TimeWrapper{}
+
+	err := copier.CopyWithOption(&to, from, copier.Option{DeepCopy: true})
+	if err != nil {
+		t.Error("should not error")
+	}
+	if !from.Time.Equal(to.Time) {
+		t.Errorf("to (%v) value should equal from (%v) value", to.Time, from.Time)
+	}
+}


### PR DESCRIPTION
This should fix issues #97 and #98.
Like PR #105, it is not specific to `time.Time`, but resolves the issue by ensuring un-exported fields of a struct are copied, even when `DeepCopy: true`.

The idea was inspired by PR #105, but the structure is quite different.
PR #105 did not resolve the issue I faced or make tests pass. This PR does both.

I retained the tests added by PRs #103 and #105 and added a few more cases that exhibit the specific issue I faced.