### PR TITLE
added converter option for type conversions

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -515,7 +515,12 @@ func lookupAndCopyWithConverter(to, from reflect.Value, converters map[converter
 			return false, err
 		}
 
-		to.Set(reflect.ValueOf(result))
+		if result != nil {
+			to.Set(reflect.ValueOf(result))
+		} else {
+			// in case we've got a nil value to copy
+			to.Set(reflect.Zero(to.Type()))
+		}
 
 		return true, nil
 	}

--- a/copier_converter_test.go
+++ b/copier_converter_test.go
@@ -137,3 +137,51 @@ func TestCopyWithConverterAndAnnotation(t *testing.T) {
 		t.Fatalf("got %q, wanted %q", dst.Field2, "test2")
 	}
 }
+
+func TestCopyWithConverterStrToStrPointer(t *testing.T) {
+	type SrcStruct struct {
+		Field1 string
+	}
+
+	type DestStruct struct {
+		Field1 *string
+	}
+
+	src := SrcStruct{
+		Field1: "",
+	}
+
+	var dst DestStruct
+
+	ptrStrType := ""
+
+	err := copier.CopyWithOption(&dst, &src, copier.Option{
+		IgnoreEmpty: true,
+		DeepCopy:    true,
+		Converters: []copier.TypeConverter{
+			{
+				SrcType: copier.String,
+				DstType: &ptrStrType,
+				Fn: func(src interface{}) (interface{}, error) {
+					s, _ := src.(string)
+
+					// return nil on empty string
+					if s == "" {
+						return nil, nil
+					}
+
+					return &s, nil
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf(`Should be able to copy from src to dst object. %v`, err)
+		return
+	}
+
+	if dst.Field1 != nil {
+		t.Fatalf("got %q, wanted nil", *dst.Field1)
+	}
+}

--- a/copier_converter_test.go
+++ b/copier_converter_test.go
@@ -1,0 +1,139 @@
+package copier_test
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/copier"
+)
+
+func TestCopyWithTypeConverters(t *testing.T) {
+	type SrcStruct struct {
+		Field1 time.Time
+		Field2 *time.Time
+		Field3 *time.Time
+		Field4 string
+	}
+
+	type DestStruct struct {
+		Field1 string
+		Field2 string
+		Field3 string
+		Field4 int
+	}
+
+	testTime := time.Date(2021, 3, 5, 1, 30, 0, 123000000, time.UTC)
+
+	src := SrcStruct{
+		Field1: testTime,
+		Field2: &testTime,
+		Field3: nil,
+		Field4: "9000",
+	}
+
+	var dst DestStruct
+
+	err := copier.CopyWithOption(&dst, &src, copier.Option{
+		IgnoreEmpty: true,
+		DeepCopy:    true,
+		Converters: []copier.TypeConverter{
+			{
+				SrcType: time.Time{},
+				DstType: copier.String,
+				Fn: func(src interface{}) (interface{}, error) {
+					s, ok := src.(time.Time)
+
+					if !ok {
+						return nil, errors.New("src type not matching")
+					}
+
+					return s.Format(time.RFC3339), nil
+				},
+			},
+			{
+				SrcType: copier.String,
+				DstType: copier.Int,
+				Fn: func(src interface{}) (interface{}, error) {
+					s, ok := src.(string)
+
+					if !ok {
+						return nil, errors.New("src type not matching")
+					}
+
+					return strconv.Atoi(s)
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf(`Should be able to copy from src to dst object. %v`, err)
+		return
+	}
+
+	dateStr := "2021-03-05T01:30:00Z"
+
+	if dst.Field1 != dateStr {
+		t.Fatalf("got %q, wanted %q", dst.Field1, dateStr)
+	}
+
+	if dst.Field2 != dateStr {
+		t.Fatalf("got %q, wanted %q", dst.Field2, dateStr)
+	}
+
+	if dst.Field3 != "" {
+		t.Fatalf("got %q, wanted %q", dst.Field3, "")
+	}
+
+	if dst.Field4 != 9000 {
+		t.Fatalf("got %q, wanted %q", dst.Field4, 9000)
+	}
+}
+
+func TestCopyWithConverterAndAnnotation(t *testing.T) {
+	type SrcStruct struct {
+		Field1 string
+	}
+
+	type DestStruct struct {
+		Field1 string
+		Field2 string `copier:"Field1"`
+	}
+
+	src := SrcStruct{
+		Field1: "test",
+	}
+
+	var dst DestStruct
+
+	err := copier.CopyWithOption(&dst, &src, copier.Option{
+		IgnoreEmpty: true,
+		DeepCopy:    true,
+		Converters: []copier.TypeConverter{
+			{
+				SrcType: copier.String,
+				DstType: copier.String,
+				Fn: func(src interface{}) (interface{}, error) {
+					s, ok := src.(string)
+
+					if !ok {
+						return nil, errors.New("src type not matching")
+					}
+
+					return s + "2", nil
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf(`Should be able to copy from src to dst object. %v`, err)
+		return
+	}
+
+	if dst.Field2 != "test2" {
+		t.Fatalf("got %q, wanted %q", dst.Field2, "test2")
+	}
+}


### PR DESCRIPTION
You can add now converter functions as an option, to convert type A to to type B.

I took some inspiration from PR #90, but implemented it a little bit diffrent. Some of the diffrences are as follows:
- passed it as an option
- no instances
- no exposure of reflect package
- no external module dependencies

Example

```golang
func main() {
	type SrcStruct struct {
		Field1 time.Time
		Field2 *time.Time
	}

	type DestStruct struct {
		Field1 string
		Field2 string
	}

	testTime := time.Date(2021, 3, 5, 1, 30, 0, 123000000, time.UTC)

	src := SrcStruct{
		Field1: testTime,
		Field2: &testTime,
	}

	var dst DestStruct

	err := copier.CopyWithOption(&dst, &src, copier.Option{
		IgnoreEmpty: true,
		DeepCopy:    true,
		Converters: []copier.TypeConverter{
			{
				SrcType: time.Time{},
				DstType: copier.String,
				Fn: func(src interface{}) (interface{}, error) {
					s, ok := src.(time.Time)

					if !ok {
						return nil, errors.New("src type not matching")
					}

					return s.Format(time.RFC3339), nil
				},
			},
		},
	})

	if err != nil {
		log.Fatal(err)
	}
	
	// DestStruct{Field1:"2021-03-05T01:30:00Z", Field2:"2021-03-05T01:30:00Z"}
	fmt.Printf("%#v", dst)
}
```

Feel free to make suggestions to any part of the PR.
