### PR TITLE
fixed copy fields breaking on unexported pointer field, close #102

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -243,7 +243,7 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 					}
 
 					if destFieldNotSet {
-						break
+						continue
 					}
 
 					toField := dest.FieldByName(destFieldName)

--- a/copier_test.go
+++ b/copier_test.go
@@ -1287,3 +1287,24 @@ func TestDeepCopyInterface(t *testing.T) {
 		t.Errorf("to value failed to be deep copied")
 	}
 }
+
+func TestDontBreakCopyOnEmptyPointer(t *testing.T) {
+	type Cat struct {
+		id   *string
+		Age  int
+		Name string
+	}
+
+	cat1 := Cat{Age: 7, Name: "Wilson"}
+	cat2 := Cat{}
+
+	copier.Copy(&cat2, &cat1)
+
+	if cat2.Age != cat1.Age {
+		t.Errorf("Field Age should be copied")
+	}
+
+	if cat2.Name != cat1.Name {
+		t.Errorf("Field Name should be copied")
+	}
+}


### PR DESCRIPTION
unexported empty pointer fields could break the copy cycle, this PR fixes that.

Credits go to @demobin8, for pointing this out in the issue #102 and for the solution.