### PR TITLE
style: simplify shouldIgnore

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,8 +3,9 @@ package copier
 import "errors"
 
 var (
-	ErrInvalidCopyDestination = errors.New("copy destination is invalid")
-	ErrInvalidCopyFrom        = errors.New("copy from is invalid")
-	ErrMapKeyNotMatch         = errors.New("map's key type doesn't match")
-	ErrNotSupported           = errors.New("not supported")
+	ErrInvalidCopyDestination        = errors.New("copy destination is invalid")
+	ErrInvalidCopyFrom               = errors.New("copy from is invalid")
+	ErrMapKeyNotMatch                = errors.New("map's key type doesn't match")
+	ErrNotSupported                  = errors.New("not supported")
+	ErrFieldNameTagStartNotUpperCase = errors.New("copier field name tag must be start upper case")
 )


### PR DESCRIPTION
Just simplify some code, no real logic update.

- Reduce the length of shouldIgnore function to one line.
- Add name for returned variable in TypeConverter to make it more understandable.
- Replace errors.New with defined ErrFieldNameTagStartNotUpperCase in errors.go.
- Early return in set function, to avoid the long `if from.IsValid()` statement.