### PR TITLE
fix:sql.NullInt32 to int32 and sql.NullByte to byte error

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -516,7 +516,7 @@ func set(to, from reflect.Value, deepCopy bool, converters map[converterPair]Typ
 			return true
 		}
 		rv := reflect.ValueOf(v)
-		if strings.HasPrefix(rv.Type().String(), "int") && strings.HasPrefix(to.Type().String(), "int") {
+		if strings.HasPrefix(rv.Type().String(), "int") && (strings.HasPrefix(to.Type().String(), "int") || strings.HasPrefix(to.Type().String(), "uint")) {
 			convert := rv.Convert(to.Type())
 			to.Set(convert)
 		} else if rv.Type().AssignableTo(to.Type()) {

--- a/copier.go
+++ b/copier.go
@@ -516,7 +516,10 @@ func set(to, from reflect.Value, deepCopy bool, converters map[converterPair]Typ
 			return true
 		}
 		rv := reflect.ValueOf(v)
-		if rv.Type().AssignableTo(to.Type()) {
+		if strings.HasPrefix(rv.Type().String(), "int") && strings.HasPrefix(to.Type().String(), "int") {
+			convert := rv.Convert(to.Type())
+			to.Set(convert)
+		} else if rv.Type().AssignableTo(to.Type()) {
 			to.Set(rv)
 		}
 	} else if from.Kind() == reflect.Ptr {


### PR DESCRIPTION
```go
type A struct {
	Id sql.NullInt32
}

type B struct {
	Id int32
}

func main() {
	var a A
	var b B
	a = A{Id: sql.NullInt32{Int32: 233, Valid: true}}
	_ = copier.Copy(&b, a)
	fmt.Println(a)
	fmt.Println(b)
}
```
the code output is。`b.Id` not set value
```
{{233 true}}
{0}
```
Because the value method of sql.NullInt32will convert int32 to Int64。`sql.NullInt16` and `sql.NullByte` are the same
```go
func (n NullInt32) Value() (driver.Value, error) {
	if !n.Valid {
		return nil, nil
	}
	return int64(n.Int32), nil
}
```
It is false to judge whether the value can be assigned
```go
 if rv.Type().AssignableTo(to.Type()) {
			to.Set(rv)
		}
```

So I added a judgment. If the data is of type int, first convert it to the corresponding type for assignment

```go
if strings.HasPrefix(rv.Type().String(), "int") && (strings.HasPrefix(to.Type().String(), "int") || strings.HasPrefix(to.Type().String(), "uint")) {
			convert := rv.Convert(to.Type())
			to.Set(convert)
		} else if rv.Type().AssignableTo(to.Type()) {
			to.Set(rv)
		}
```
