### PR TITLE
copier fails silently when source field implements valuer interface

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -518,6 +518,10 @@ func set(to, from reflect.Value, deepCopy bool, converters map[converterPair]Typ
 		rv := reflect.ValueOf(v)
 		if rv.Type().AssignableTo(to.Type()) {
 			to.Set(rv)
+		} else if from.Kind() == reflect.Ptr {
+			return set(to, from.Elem(), deepCopy, converters)
+		} else {
+			return false
 		}
 	} else if from.Kind() == reflect.Ptr {
 		return set(to, from.Elem(), deepCopy, converters)


### PR DESCRIPTION
Think that I have a CompanyEntity struct which is used in database layer and a CompanyModel in business layer with same fields. In CompanyEntity I have a struct or slice field which is saved as json text in the database by implementing valuer/scanner. With this setup copier fails to copy the field implementing valuer from entity to model because what Value() method returns is not convertible to destination field type which is a struct. 

This is a test with above mentioned setup. I expect copier to pass this test but current version fails to do so. Pr includes a simple solution.
```go
import (
	"database/sql/driver"
	"encoding/json"
	"testing"
)

type CompanyEntity struct {
	Field1  string
	Field2  string
	Persons Persons
}

type Persons []PersonEntity

func (m Persons) Value() (driver.Value, error) {
	b, err := json.Marshal(m)
	if err != nil {
		return nil, err
	}

	return b, nil
}

type CompanyModel struct {
	Field1  string
	Field2  string
	Persons []PersonModel
}

type PersonEntity struct {
	Name    string
	Surname string
}

type PersonModel struct {
	Name    string
	Surname string
}

func TestCopier(t *testing.T) {
	s := CompanyEntity{
		Field1: "f1",
		Field2: "f2",
		Persons: []PersonEntity{
			{
				Name:    "john",
				Surname: "doe",
			},
		},
	}

	d := CompanyModel{}
	if err := Copy(&d, &s); err != nil{
		t.Error(err)
	}

	if len(d.Persons) == 0 {
		t.Error("copy is not successful")
	}
}
```