### PR TITLE
fix json error when struct field is slice and is nil

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -174,6 +174,10 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 	}
 
 	if from.Kind() == reflect.Slice && to.Kind() == reflect.Slice && fromType.ConvertibleTo(toType) {
+		// if both from and to slices are nil, do nothing
+		if to.IsNil() && from.IsNil() {
+			return
+		}
 		if to.IsNil() {
 			slice := reflect.MakeSlice(reflect.SliceOf(to.Type().Elem()), from.Len(), from.Cap())
 			to.Set(slice)

--- a/copier_test.go
+++ b/copier_test.go
@@ -2,6 +2,7 @@ package copier_test
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -1608,6 +1609,39 @@ func TestDeepCopySimpleTime(t *testing.T) {
 	}
 	if !from.Equal(to) {
 		t.Errorf("to (%v) value should equal from (%v) value", to, from)
+	}
+}
+
+func TestDeepCopyWithNilByteSlices(t *testing.T) {
+	type From struct {
+		Flags json.RawMessage
+	}
+
+	type To struct {
+		Flags json.RawMessage
+	}
+
+	from := From{}
+	to := To{}
+
+	err := copier.CopyWithOption(&to, &from, copier.Option{
+		DeepCopy: true,
+	})
+	if err != nil {
+		t.Error("error when copying")
+	}
+	if to.Flags != nil {
+		t.Error("Flags byte array is not nil", to.Flags, from.Flags)
+	}
+
+	_, err = json.Marshal(from)
+	if err != nil {
+		t.Error("error when marshalling from struct")
+	}
+
+	_, err = json.Marshal(to)
+	if err != nil {
+		t.Error("error when marshalling from struct")
 	}
 }
 


### PR DESCRIPTION
When using copier for a struct with a nil byte slice as a field to a target struct which contains a similar nil byte slice field, the target slice field is being set with an empty slice instead of nil.

This cause issues, when the resulting target slice is converted to json using json.Marsha() method. Added a testcase for the same.