### PR TITLE
Fixed issue with nested pointer structs

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -270,7 +270,7 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 				}
 
 				srcFieldName, destFieldName := getFieldName(name, flgs)
-				if fromField := source.FieldByName(srcFieldName); fromField.IsValid() && !shouldIgnore(fromField, opt.IgnoreEmpty) {
+				if fromField := fieldByNameOrZeroValue(source, srcFieldName); fromField.IsValid() && !shouldIgnore(fromField, opt.IgnoreEmpty) {
 					// process for nested anonymous field
 					destFieldNotSet := false
 					if f, ok := dest.Type().FieldByName(destFieldName); ok {
@@ -398,6 +398,16 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 	}
 
 	return
+}
+
+func fieldByNameOrZeroValue(source reflect.Value, fieldName string) (value reflect.Value) {
+	defer func() {
+		if err := recover(); err != nil {
+			value = reflect.Value{}
+		}
+	}()
+
+	return source.FieldByName(fieldName)
 }
 
 func copyUnexportedStructFields(to, from reflect.Value) {

--- a/copier_test.go
+++ b/copier_test.go
@@ -1732,3 +1732,33 @@ func TestEmptySlice(t *testing.T) {
 		t.Error("from should be empty slice nil")
 	}
 }
+
+func TestNestedNilPointerStruct(t *testing.T) {
+	type destination struct {
+		Title string
+	}
+
+	type NestedSource struct {
+		ID int
+	}
+
+	type source struct {
+		Title string
+		*NestedSource
+	}
+
+	from := &source{
+		Title: "A title to be copied",
+	}
+
+	to := destination{}
+
+	err := copier.Copy(&to, from)
+	if err != nil {
+		t.Error("should not error")
+	}
+
+	if from.Title != to.Title {
+		t.Errorf("to (%v) value should equal from (%v) value", to.Title, from.Title)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/jinzhu/copier/issues/99

An alternative to using defer/recover is to utilize the `FieldByIndexErr`, but it's only available in 1.18+

```
structField, ok := source.Type().FieldByName(fieldName)
if !ok {
	return reflect.Value{}
}

field, err := source.FieldByIndexErr(structField.Index)
if err != nil {
	return reflect.Value{}
}

return field
```