### PR TITLE
fix case-insensitivity code

### DIFF
--- a/copier_benchmark_test.go
+++ b/copier_benchmark_test.go
@@ -29,7 +29,7 @@ func BenchmarkNamaCopy(b *testing.B) {
 	for x := 0; x < b.N; x++ {
 		employee := &Employee{
 			Name:      user.Name,
-			NickName:  &user.Nickname,
+			Nickname:  &user.Nickname,
 			Age:       int64(user.Age),
 			FakeAge:   int(*user.FakeAge),
 			DoubleAge: user.DoubleAge(),


### PR DESCRIPTION
This commit was merged into `master` but breaks all the unit tests: https://github.com/jinzhu/copier/commit/61dc501cb9128863639033ea8c58f70c8b308d62

This is because it changes the default behavior of Copier to be case-insensitive, which breaks tests and compatibility, this pull request fixes that bug.

I've duplicated the tests because it was a bit difficult to do it in any other way because tye types don't match, it would require generics or reflection and I don't want to complicate things that much, and this way I can be sure it's working correctly.

checkout and do `go test ./...`