### PR TITLE
feat: Support custom file name mappings

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        go: ['1.16', '1.17', '1.18', '1.19']
+        go: ['1.17', '1.18', '1.19', '1.20', '1.21']
         platform: [ubuntu-latest, macos-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 

--- a/copier_different_type_test.go
+++ b/copier_different_type_test.go
@@ -133,7 +133,7 @@ func TestAssignableType(t *testing.T) {
 
 	ts3 := &TypeStruct3{}
 
-	copier.Copy(&ts3, &ts)
+	copier.CopyWithOption(&ts3, &ts, copier.Option{CaseSensitive: true})
 
 	if v, ok := ts3.Field1.(string); !ok {
 		t.Error("Assign to interface{} type did not succeed")

--- a/copier_field_name_mapping_test.go
+++ b/copier_field_name_mapping_test.go
@@ -1,0 +1,44 @@
+package copier_test
+
+import (
+	"github.com/jinzhu/copier"
+	"reflect"
+	"testing"
+)
+
+func TestCustomFieldName(t *testing.T) {
+	type User1 struct {
+		Id      int64
+		Name    string
+		Address []string
+	}
+
+	type User2 struct {
+		Id2      int64
+		Name2    string
+		Address2 []string
+	}
+
+	u1 := User1{Id: 1, Name: "1", Address: []string{"1"}}
+	var u2 User2
+	err := copier.CopyWithOption(&u2, u1,
+		copier.Option{FieldNameMapping: []copier.FieldNameMapping{
+			{SrcType: u1, DstType: u2, Mapping: map[string]string{"Id": "Id2", "Name": "Name2", "Address": "Address2"}},
+		}})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if u1.Id != u2.Id2 {
+		t.Error("copy id failed.")
+	}
+
+	if u1.Name != u2.Name2 {
+		t.Error("copy name failed.")
+	}
+
+	if !reflect.DeepEqual(u1.Address, u2.Address2) {
+		t.Error("copy address failed.")
+	}
+}

--- a/copier_field_name_mapping_test.go
+++ b/copier_field_name_mapping_test.go
@@ -21,10 +21,13 @@ func TestCustomFieldName(t *testing.T) {
 
 	u1 := User1{Id: 1, Name: "1", Address: []string{"1"}}
 	var u2 User2
-	err := copier.CopyWithOption(&u2, u1,
-		copier.Option{FieldNameMapping: []copier.FieldNameMapping{
-			{SrcType: u1, DstType: u2, Mapping: map[string]string{"Id": "Id2", "Name": "Name2", "Address": "Address2"}},
-		}})
+	err := copier.CopyWithOption(&u2, u1, copier.Option{FieldNameMapping: []copier.FieldNameMapping{
+		{SrcType: u1, DstType: u2,
+			Mapping: map[string]string{
+				"Id":      "Id2",
+				"Name":    "Name2",
+				"Address": "Address2"}},
+	}})
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Custom field name mappings to copy values with different names in `fromValue` and `toValue` types. Examples can be found in `copier_different_field_name_test.go`. 

resolve #139 

```go
type User1 struct {
	Id      int64
	Name    string
	Address []string
}

type User2 struct {
	Id2      int64
	Name2    string
	Address2 []string
}

u1 := User1{Id: 1, Name: "1", Address: []string{"1"}}
var u2 User2
err := copier.CopyWithOption(&u2, u1, copier.Option{FieldNameMapping: []copier.FieldNameMapping{
	{SrcType: u1, DstType: u2,
		Mapping: map[string]string{
			"Id":      "Id2",
			"Name":    "Name2",
			"Address": "Address2"}},
}})
```