### PR TITLE
feat: if err occur, dst will recover to init

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -136,6 +136,15 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 		return ErrInvalidCopyFrom
 	}
 
+	cacheToValue := indirect(reflect.New(to.Type()))
+	cacheToValue.Set(to)
+	defer func() {
+		//  if err occur, toValue needs to recover to init state.
+		if err != nil {
+			to.Set(cacheToValue)
+		}
+	}()
+
 	fromType, isPtrFrom := indirectType(from.Type())
 	toType, _ := indirectType(to.Type())
 


### PR DESCRIPTION
## Description:
#158 <br/>
Cache the dst value before executing the copy in case of an error. If an error occurs, recover back to the initial state

