### PR TITLE
Enable skipping unexported fields

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -47,6 +47,9 @@ type Option struct {
 	// Custom field name mappings to copy values with different names in `fromValue` and `toValue` types.
 	// Examples can be found in `copier_field_name_mapping_test.go`.
 	FieldNameMapping []FieldNameMapping
+
+	// SkipUnexported will skip private fields: they will not be copied
+	SkipUnexported bool
 }
 
 func (opt Option) converters() map[converterPair]TypeConverter {
@@ -320,7 +323,9 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 
 		// check source
 		if source.IsValid() {
-			copyUnexportedStructFields(dest, source)
+			if !opt.SkipUnexported {
+				copyUnexportedStructFields(dest, source)
+			}
 
 			// Copy from source field to dest field or method
 			fromTypeFields := deepFields(fromType)

--- a/copier_test.go
+++ b/copier_test.go
@@ -380,6 +380,10 @@ func TestStructField(t *testing.T) {
 		DeepCopy: true,
 	}
 
+	optionsSkipUnexported := copier.Option{
+		SkipUnexported: true,
+	}
+
 	checkDetail := func(t *testing.T, source Detail, target Detail) {
 		if source.Info1 != target.Info1 {
 			t.Errorf("info1 is diff: source: %v, target: %v", source.Info1, target.Info1)
@@ -701,6 +705,52 @@ func TestStructField(t *testing.T) {
 			}
 			if to.Notes[1] == (*from.Notes)[1] {
 				t.Errorf("should be different")
+			}
+		})
+	})
+
+	t.Run("should handle unexported fields", func(t *testing.T) {
+		t.Run("should copy unexported fields", func(t *testing.T) {
+			from := &struct {
+				unexportedField string
+			}{
+				unexportedField: "foo",
+			}
+
+			to := &struct {
+				unexportedField string
+			}{}
+
+			err := copier.Copy(to, from)
+			if err != nil {
+				t.Errorf("should not return an error")
+				return
+			}
+
+			if to.unexportedField != from.unexportedField {
+				t.Errorf("should be equal")
+			}
+		})
+
+		t.Run("should not copy unexported fields with disallowed by the option", func(t *testing.T) {
+			from := &struct {
+				unexportedField string
+			}{
+				unexportedField: "foo",
+			}
+
+			to := &struct {
+				unexportedField string
+			}{}
+
+			err := copier.CopyWithOption(to, from, optionsSkipUnexported)
+			if err != nil {
+				t.Errorf("should not return an error")
+				return
+			}
+
+			if to.unexportedField == from.unexportedField {
+				t.Errorf("should not be equal")
 			}
 		})
 	})


### PR DESCRIPTION
In many cases it may be undesirable to copy unexported fields. This PR introduces the ability to disable copying these fields, as an option on the `Copier` rather than on the fields. This enables a generalized behavior that does not require modifications to struct tags on packages you don't own, in order to copy them without perhaps overriding private values.