### PR TITLE
chore: remove duplicated benchmark case

### DIFF
--- a/copier_benchmark_test.go
+++ b/copier_benchmark_test.go
@@ -15,14 +15,6 @@ func BenchmarkCopyStruct(b *testing.B) {
 	}
 }
 
-func BenchmarkCopyStructFields(b *testing.B) {
-	var fakeAge int32 = 12
-	user := User{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin", Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}
-	for x := 0; x < b.N; x++ {
-		copier.Copy(&Employee{}, &user)
-	}
-}
-
 func BenchmarkNamaCopy(b *testing.B) {
 	var fakeAge int32 = 12
 	user := User{Name: "Jinzhu", Nickname: "jinzhu", Age: 18, FakeAge: &fakeAge, Role: "Admin", Notes: []string{"hello world", "welcome"}, flags: []byte{'x'}}


### PR DESCRIPTION
`BenchmarkCopyStruct` and `BenchmarkCopyStructFields` are duplicated benchmark cases and I remove the `BenchmarkCopyStructFields`.