### PR TITLE
fix: fix referencing the loop variable and avoid slice grow

### DIFF
--- a/copier_benchmark_test.go
+++ b/copier_benchmark_test.go
@@ -35,9 +35,12 @@ func BenchmarkNamaCopy(b *testing.B) {
 			DoubleAge: user.DoubleAge(),
 		}
 
-		for _, note := range user.Notes {
-			employee.Notes = append(employee.Notes, &note)
+		employee.Notes = make([]*string, len(user.Notes))
+		for idx, note := range user.Notes {
+			tmp := note
+			employee.Notes[idx] = &tmp
 		}
+
 		employee.Role(user.Role)
 	}
 }


### PR DESCRIPTION
The semantics of for loop variables is controlled by the language version in the module’s go.mod file when using go version 1.22 or later. That is it works well when the version in go module is 1.22 or later. Otherwise the reference using pointer will capture the same loop variable.

In addition, making slice with length avoids slice growing to ensure fairness. 

References:
- https://go.dev/doc/go1.21
- https://go.dev/wiki/LoopvarExperiment