### PR TITLE
Fix case-insensitive field matching when both exported and unexported fields exist

### DIFF
--- a/copier.go
+++ b/copier.go
@@ -875,5 +875,41 @@ func fieldByName(v reflect.Value, name string, caseSensitive bool) reflect.Value
 		return v.FieldByName(name)
 	}
 
-	return v.FieldByNameFunc(func(n string) bool { return strings.EqualFold(n, name) })
+	// For case-insensitive matching, prioritize exported fields
+	// First try exact match (might be the exported field)
+	if field := v.FieldByName(name); field.IsValid() {
+		return field
+	}
+
+	// If exact match fails, perform case-insensitive matching
+	// but prioritize exported fields
+	var candidates []reflect.Value
+	var candidateNames []string
+
+	structType := v.Type()
+	for i := 0; i < structType.NumField(); i++ {
+		fieldType := structType.Field(i)
+		if strings.EqualFold(fieldType.Name, name) {
+			field := v.Field(i)
+			candidates = append(candidates, field)
+			candidateNames = append(candidateNames, fieldType.Name)
+		}
+	}
+
+	// If there are multiple candidate fields, prioritize exported ones
+	for i, candidate := range candidates {
+		fieldName := candidateNames[i]
+		// Check if field is exported (starts with uppercase letter)
+		if len(fieldName) > 0 && unicode.IsUpper(rune(fieldName[0])) {
+			return candidate
+		}
+	}
+
+	// If no exported field found, return the first match (preserve original behavior)
+	if len(candidates) > 0 {
+		return candidates[0]
+	}
+
+	// If no match found, return zero value
+	return reflect.Value{}
 }

--- a/copier.go
+++ b/copier.go
@@ -211,7 +211,7 @@ func copier(toValue interface{}, fromValue interface{}, opt Option) (err error) 
 					to.SetMapIndex(toKey, toValue)
 					break
 				}
-				elemType = reflect.PointerTo(elemType)
+				elemType = reflect.PtrTo(elemType)
 				toValue = toValue.Addr()
 			}
 		}

--- a/copier.go
+++ b/copier.go
@@ -882,25 +882,21 @@ func fieldByName(v reflect.Value, name string, caseSensitive bool) reflect.Value
 	}
 
 	// If exact match fails, perform case-insensitive matching
-	// but prioritize exported fields
+	// but prioritize exported fields while preserving promoted-field lookup.
 	var candidates []reflect.Value
-	var candidateNames []string
+	var candidateFields []reflect.StructField
 
-	structType := v.Type()
-	for i := 0; i < structType.NumField(); i++ {
-		fieldType := structType.Field(i)
+	for _, fieldType := range reflect.VisibleFields(v.Type()) {
 		if strings.EqualFold(fieldType.Name, name) {
-			field := v.Field(i)
+			field := v.FieldByIndex(fieldType.Index)
 			candidates = append(candidates, field)
-			candidateNames = append(candidateNames, fieldType.Name)
+			candidateFields = append(candidateFields, fieldType)
 		}
 	}
 
 	// If there are multiple candidate fields, prioritize exported ones
 	for i, candidate := range candidates {
-		fieldName := candidateNames[i]
-		// Check if field is exported (starts with uppercase letter)
-		if len(fieldName) > 0 && unicode.IsUpper(rune(fieldName[0])) {
+		if candidateFields[i].IsExported() {
 			return candidate
 		}
 	}

--- a/copier_case_insensitive_test.go
+++ b/copier_case_insensitive_test.go
@@ -1,0 +1,71 @@
+package copier
+
+import (
+	"testing"
+)
+
+// Test case for issue where case-insensitive field matching
+// fails when there are both exported and unexported fields with similar names
+func TestCaseInsensitiveFieldMatching(t *testing.T) {
+	// Simulate protobuf generated struct with both unexported 'state' and exported 'State' fields
+	type ProtoStruct struct {
+		state      uint32
+		PageNumber int32 `json:"pageNumber"`
+		State      int32 `json:"state"`
+	}
+
+	type SourceStruct struct {
+		PageNumber int32 `json:"pageNumber"`
+		State      int32 `json:"state"`
+	}
+
+	source := SourceStruct{
+		PageNumber: 1,
+		State:      99,
+	}
+
+	dest := &ProtoStruct{}
+
+	err := Copy(dest, &source)
+	if err != nil {
+		t.Fatalf("Copy failed: %v", err)
+	}
+
+	// Verify that the exported State field was copied correctly
+	if dest.State != source.State {
+		t.Errorf("State field not copied correctly. Expected: %d, Got: %d", source.State, dest.State)
+	}
+
+	if dest.state == uint32(source.State) {
+		t.Errorf("state field not copied correctly. Expected: %d, Got: %d", source.State, dest.state)
+	}
+
+	if dest.PageNumber != source.PageNumber {
+		t.Errorf("PageNumber field not copied correctly. Expected: %d, Got: %d", source.PageNumber, dest.PageNumber)
+	}
+}
+
+// Test that exact case matching still works
+func TestExactCaseMatching(t *testing.T) {
+	type Source struct {
+		Name string
+		Age  int
+	}
+
+	type Dest struct {
+		Name string
+		Age  int
+	}
+
+	source := Source{Name: "John", Age: 30}
+	dest := &Dest{}
+
+	err := Copy(dest, &source)
+	if err != nil {
+		t.Fatalf("Copy failed: %v", err)
+	}
+
+	if dest.Name != source.Name || dest.Age != source.Age {
+		t.Errorf("Fields not copied correctly. Expected: %+v, Got: %+v", source, *dest)
+	}
+}

--- a/copier_case_insensitive_test.go
+++ b/copier_case_insensitive_test.go
@@ -36,8 +36,8 @@ func TestCaseInsensitiveFieldMatching(t *testing.T) {
 		t.Errorf("State field not copied correctly. Expected: %d, Got: %d", source.State, dest.State)
 	}
 
-	if dest.state == uint32(source.State) {
-		t.Errorf("state field not copied correctly. Expected: %d, Got: %d", source.State, dest.state)
+	if dest.state != 0 {
+		t.Errorf("unexported field state should remain zero, got: %d", dest.state)
 	}
 
 	if dest.PageNumber != source.PageNumber {
@@ -67,5 +67,44 @@ func TestExactCaseMatching(t *testing.T) {
 
 	if dest.Name != source.Name || dest.Age != source.Age {
 		t.Errorf("Fields not copied correctly. Expected: %+v, Got: %+v", source, *dest)
+	}
+}
+
+func TestCaseInsensitiveMatchingWithEmbeddedField(t *testing.T) {
+	type Embedded struct {
+		Name string
+	}
+
+	type Dest struct {
+		name string
+		Embedded
+	}
+
+	type Source struct {
+		NAME string
+	}
+
+	source := Source{
+		NAME: "John",
+	}
+
+	dest := &Dest{}
+
+	err := CopyWithOption(dest, &source, Option{
+		CaseSensitive: false,
+	})
+	if err != nil {
+		t.Fatalf("Copy failed: %v", err)
+	}
+
+	if dest.Name != source.NAME {
+		t.Fatalf("embedded promoted field not copied correctly. expected %q, got %q", source.NAME, dest.Name)
+	}
+
+	if dest.Embedded.Name != source.NAME {
+		t.Fatalf("embedded field not copied correctly. expected %q, got %q", source.NAME, dest.Embedded.Name)
+	}
+	if dest.name != "" {
+		t.Fatalf("unexported field should not be copied, got %q", dest.name)
 	}
 }


### PR DESCRIPTION
## 🐛 Problem Description

When using case-insensitive field matching, `copier` may incorrectly match unexported fields when the target struct contains both exported (e.g., `State`) and unexported fields (e.g., `state`) with similar names, leading to copy failures or data loss.

This issue is particularly common when working with protobuf-generated structs, as the protobuf compiler generates structs containing both public and private fields.

### Reproduction Scenario
```go
type ProtoStruct struct {
    state      uint32  // internal protobuf field
    State      int32   `json:"state"` // public field
}

type SourceStruct struct {
    State int32 `json:"state"`
}
```

In case-insensitive mode, `copier` might match the private `state` field instead of the public `State` field, causing copy operations to fail.

## ✅ Solution

Reimplemented the case-insensitive matching logic in the `fieldByName` function:

1. **Exact Match First**: Attempt exact field name matching initially
2. **Collect Candidates**: If exact matching fails, collect all case-insensitive matching fields
3. **Prioritize Exported Fields**: Among multiple candidates, prioritize exported fields (starting with uppercase letter)
4. **Backward Compatibility**: If no exported field is found, return the first match (preserving original behavior)

### Key Improvements
- 🔍 Smart field priority: Exported fields > Unexported fields
- 🚀 Better protobuf support
- 📦 Maintains backward compatibility
- ✨ Aligns with Go's field access conventions

## 🧪 Test Coverage

Added comprehensive test cases:

- ✅ Test exported/unexported field priority selection
- ✅ Test exact matching still works correctly
- ✅ Test field copying in protobuf scenarios
- ✅ Verify backward compatibility

## 📋 Changes

- [x] Fixed `fieldByName` function in `copier.go`
- [x] Added `copier_case_insensitive_test.go` test file
- [x] Maintained API compatibility
- [x] All existing tests pass

## 🔄 Impact

This fix:
- ✅ Resolves protobuf-generated struct copying issues
- ✅ Improves field matching accuracy
- ✅ Won't break existing code
- ✅ Follows Go's exported field priority principle

## 📚 Background

This fix addresses field matching ambiguity encountered in real-world projects using `copier`, particularly in microservice architectures using protobuf. The solution ensures that when multiple fields match case-insensitively, the library intelligently selects the most appropriate field according to Go's visibility conventions.

## 🧪 Testing

```bash
go test -v ./... -run TestCaseInsensitiveFieldMatching
go test -v ./...
```

All tests pass, confirming the fix works correctly while maintaining backward compatibility.